### PR TITLE
fixed documentation in README. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Let's consider the task of classifying MNIST with a multilayer perceptron (MLP).
 
 ```python
 $ from deepx.nn import *
+$ from deepx.optimize import *
 $ mlp = Vector(784) >> Tanh(200) >> Tanh(200) >> Softmax(10)
 ```
 


### PR DESCRIPTION
must import * from deepx.optimize to access optimizers and loss functions. else the rest of the code in the example will die because cross_entropy doesn't exist in the global namespace